### PR TITLE
Make background light blue in light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       }
 
       :root[data-theme="light"] {
-        --bg-color: #f0f0f0;
+        --bg-color: #e6f2ff;
         --border-color: #ccc;
         --wall-color: 0xbdc3c7;
         --player-color: 0x2980b9;


### PR DESCRIPTION
Changed the background color in light mode to light blue by modifying the CSS variable --bg-color in the light theme.