### PR TITLE
Make shitcoin boxes black

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         --player-color: 0x3498db;
         --exit-color: 0xf1c40f;
         --bitcoin-color: 0xff9900;
-        --shitcoin-color: 0xd4a76a;
+        --shitcoin-color: 0x000000;
         --status-bar-color: 0x000000;
       }
 
@@ -23,7 +23,7 @@
         --player-color: 0x2980b9;
         --exit-color: 0xf39c12;
         --bitcoin-color: 0xff7700;
-        --shitcoin-color: 0xb5906c;
+        --shitcoin-color: 0x000000;
         --status-bar-color: 0x333333;
       }
 
@@ -125,7 +125,7 @@
               player: 0x3498db,
               exit: 0xf1c40f,
               bitcoin: 0xff9900,
-              shitcoin: 0xd4a76a,
+              shitcoin: 0x000000,
               statusBar: 0x000000,
             }
           : {
@@ -133,7 +133,7 @@
               player: 0x2980b9,
               exit: 0xf39c12,
               bitcoin: 0xff7700,
-              shitcoin: 0xb5906c,
+              shitcoin: 0x000000,
               statusBar: 0x333333,
             };
       }


### PR DESCRIPTION
This PR changes the color of shitcoin boxes to black in both dark and light themes.

Fixes Linear issue 10fb562b.