### PR TITLE
Reduce bitcoin accumulation and shitcoin rekt message display time

### DIFF
--- a/index.html
+++ b/index.html
@@ -550,7 +550,7 @@
           isDisplayingMessage = true;
           const message = messageQueue.shift();
           statusText.setText(message);
-          this.time.delayedCall(3000, () => {
+          this.time.delayedCall(1500, () => {
             statusText.setText("");
             isDisplayingMessage = false;
             showNextMessage.call(this);


### PR DESCRIPTION
This PR reduces the display time for bitcoin accumulation and shitcoin rekt messages from 3 seconds to 1.5 seconds, making the game feel more responsive.

Linear Issue: https://linear.app/linear-cursor/issue/LIN-54efb30f/reduce-the-time-that-bitcoin-accumulation-and-shitcoin-rekt-messages-show